### PR TITLE
Get Play Services version.

### DIFF
--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -22,7 +22,7 @@
             </feature>
         </config-file>
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
-           <meta-data  android:name="com.google.android.gms.version"   android:value="7327000"/>
+           <meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version"/>
 			<activity  android:name="com.google.android.gms.ads.AdActivity"  android:configChanges="keyboard|keyboardHidden|orientation|screenLayout|uiMode|screenSize|smallestScreenSize"/>
         </config-file>
         <config-file target="AndroidManifest.xml" parent="/*">


### PR DESCRIPTION
This solves a bunch of issues for me. Most other plugins call play services this way, but with the hardcoded version it gets added to the manifest twice and fails on build.